### PR TITLE
Add instance to destination key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master/unreleased
+
+* support pickle protocol versions 0, 1, 2, 3 & 4 + accept pickle arrays + send pickle tuples. #341
+
 # v0.11.0: memleak fix, new logging, major input refactor and more. Nov 9, 2018
 
 * BREAKING: switch to logrus for logging. #317, #326

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -74,8 +74,8 @@ func New(routeName, prefix, sub, regex, addr, spoolDir string, spool, pickle boo
 	if err != nil {
 		return nil, err
 	}
-	addr, instance := addrInstanceSplit(addr)
 	key := util.Key(routeName, addr)
+	addr, instance := addrInstanceSplit(addr)
 	dest := &Destination{
 		Matcher:              *m,
 		Addr:                 addr,


### PR DESCRIPTION
-this solve the issue of key overlapping when two destinations
use the same ip:port; that issue was causing different
connections to use the same spool file.

Signed-off-by: Jean-Francois Weber-Marx jfwm@hotmail.com