### PR TITLE
Remove exit at the end of the main

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -206,7 +206,6 @@ func main() {
 	if !manager.Stop(inputs, shutdownTimeout) {
 		os.Exit(1)
 	}
-	os.Exit(0)
 }
 
 func expandVars(in string) (out string) {


### PR DESCRIPTION
Defered statements are not executed when calling os.Exit. As a
consequence the profile file was never written when running the relay
with -cpuprofile.