### PR TITLE
Try to unregister before registering again a collector

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -20,6 +20,7 @@ func NewSafeRegistry() *SafeRegistry {
 
 func (r *SafeRegistry) MustRegister(collectors ...prometheus.Collector) {
 	for _, cltor := range collectors {
+		r.Unregister(cltor)
 		if err := r.Register(cltor); err != nil {
 			logrus.Warnf("failed to register a collector: %s", err)
 		}


### PR DESCRIPTION
This will avoid having dangling collectors when connections are dropped/opened, or runtime modification of the dest/aggr/route/..