### PR TITLE
Sorted mutators

### DIFF
--- a/destination/conn.go
+++ b/destination/conn.go
@@ -79,7 +79,9 @@ func NewConn(key, addr string, periodFlush time.Duration, pickle bool, connBufSi
 		flushErr:    make(chan error),
 		periodFlush: periodFlush,
 		keepSafe:    NewKeepSafe(keepsafe_initial_cap, keepsafe_keep_duration),
-		bm:          metrics.NewBufferMetrics("destination_conn", key, nil, []float64{50, 100, 200, 300, 500, 800, 1200}),
+		bm: metrics.NewBufferMetrics("destination_conn", key, prometheus.Labels{
+			"address": addr,
+		}, []float64{250, 500, 750, 1000, 1250, 1500}),
 	}
 
 	connObj.bm.Size.Set(float64(connBufSize))

--- a/metrics/spool_metrics.go
+++ b/metrics/spool_metrics.go
@@ -21,7 +21,7 @@ func NewSpoolMetrics(namespace, id string, additionnalLabels prometheus.Labels) 
 	}
 	additionnalLabels["id"] = id
 	sm := SpoolMetrics{}
-	sm.Buffer = NewBufferMetrics(fmt.Sprintf("%s_%s", namespace, SpoolSystem), id, additionnalLabels, nil)
+	sm.Buffer = NewBufferMetrics(fmt.Sprintf("%s_%s", namespace, SpoolSystem), id, additionnalLabels, []float64{250, 500, 750, 1000, 1250, 1500})
 	sm.IncomingMetrics = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   namespace,
 		Subsystem:   SpoolSystem,

--- a/route/consistent_hashing.go
+++ b/route/consistent_hashing.go
@@ -165,6 +165,7 @@ func (cs *ConsistentHashing) Dispatch(buf []byte) {
 		// dest should handle this as quickly as it can
 		log.Tracef("route %s sending to dest %s: %s", cs.key, dest.Key, name)
 		dest.In <- buf
+		cs.baseRoute.rm.OutMetrics.Inc()
 	} else {
 		log.Errorf("could not parse %s", buf)
 	}

--- a/route/consistent_hashing.go
+++ b/route/consistent_hashing.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"sort"
 	"sync"
 
 	"github.com/coocood/freecache"
@@ -46,6 +47,9 @@ func NewRoutingMutator(table map[string]string, cacheSize int) (*RoutingMutator,
 			mutators = append(mutators, &Mutator{re, []byte(out)})
 		}
 	}
+	sort.SliceStable(mutators, func(i, j int) bool {
+		return mutators[i].Matcher.String() < mutators[j].Matcher.String()
+	})
 
 	var cache *freecache.Cache
 	if cacheSize > 0 {


### PR DESCRIPTION
golang runtime randomize the map key order

To fix a potential conflict if multiple matches exists, this will use the regex string format to sort mutators