### PR TITLE
Improve kafka input to support more configuration options

### DIFF
--- a/cfg/input.go
+++ b/cfg/input.go
@@ -72,21 +72,22 @@ func (c *ListenerConfig) Build() (input.Input, error) {
 
 // for more informations about the fields, go look at https://github.com/segmentio/kafka-go/blob/master/reader.go#L291
 type KafkaConfig struct {
-	baseInputConfig  `mapstructure:",squash"`
-	ID               string        `mapstructure:"client_id,omitempty"`
-	Brokers          []string      `mapstructure:"brokers,omitempty"`
-	Topic            string        `mapstructure:"topic,omitempty"`
-	ConsumerGroupID  string        `mapstructure:"consumer_group_id,omitempty"`
-	QueueCapacity    int           `mapstructure:"queue_capacity,omitempty"`
-	MinBytes         int           `mapstructure:"min_bytes,omitempty"`
-	MaxBytes         int           `mapstructure:"max_bytes,omitempty"`
-	CommitInterval   time.Duration `mapstructure:"commit_interval,omitempty"`
-	SessionTimeout   time.Duration `mapstructure:"session_timeout,omitempty"`
-	RebalanceTimeout time.Duration `mapstructure:"rebalance_timeout,omitempty"`
-	BackoffMin       time.Duration `mapstructure:"backoff_min,omitempty"`
-	BackoffMax       time.Duration `mapstructure:"backoff_max,omitempty"`
-	MaxAttempts      int           `mapstructure:"max_attempts,omitempty"`
-	ReturnErrors     bool          `mapstructure:"return_errors,omitempty"`
+	baseInputConfig     `mapstructure:",squash"`
+	ID                  string        `mapstructure:"client_id,omitempty"`
+	Brokers             []string      `mapstructure:"brokers,omitempty"`
+	Topic               string        `mapstructure:"topic,omitempty"`
+	ConsumerGroupID     string        `mapstructure:"consumer_group_id,omitempty"`
+	QueueCapacity       int           `mapstructure:"queue_capacity,omitempty"`
+	MinBytes            int           `mapstructure:"min_bytes,omitempty"`
+	MaxBytes            int           `mapstructure:"max_bytes,omitempty"`
+	CommitInterval      time.Duration `mapstructure:"commit_interval,omitempty"`
+	SessionTimeout      time.Duration `mapstructure:"session_timeout,omitempty"`
+	RebalanceTimeout    time.Duration `mapstructure:"rebalance_timeout,omitempty"`
+	BackoffMin          time.Duration `mapstructure:"backoff_min,omitempty"`
+	BackoffMax          time.Duration `mapstructure:"backoff_max,omitempty"`
+	MaxAttempts         int           `mapstructure:"max_attempts,omitempty"`
+	ReturnErrors        bool          `mapstructure:"return_errors,omitempty"`
+	InitialOffsetOldest bool          `mapstructure:"initial_offset_oldest,omitempty"`
 }
 
 func (c *KafkaConfig) Build() (input.Input, error) {
@@ -158,7 +159,10 @@ func (c *KafkaConfig) Build() (input.Input, error) {
 
 	kafkaConfig.ClientID = c.ID
 
-	kafkaConfig.Consumer.Offsets.Initial = sarama.OffsetNewest
+	if c.InitialOffsetOldest {
+		kafkaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
+	}
+
 	kafkaConfig.Version = sarama.V2_2_0_0
 
 	h, err := c.Handler()

--- a/cfg/input.go
+++ b/cfg/input.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/graphite-ng/carbon-relay-ng/encoding"
 	"github.com/graphite-ng/carbon-relay-ng/input"
+	"github.com/graphite-ng/carbon-relay-ng/util"
 )
 
 const (
@@ -33,7 +34,7 @@ const (
 )
 
 var (
-	kafkaEmptyConsumerGroupError = errors.New("consumer_group can't be empty in kafka config")
+	kafkaEmptyConsumerGroupError = errors.New("consumer_group_id can't be empty in kafka config")
 	kafkaEmptyTopicError         = errors.New("topic can't be empty in kafka config")
 	kafkaEmptyBrokersError       = errors.New("brokers can't be empty in kafka config")
 	noInputError                 = errors.New("no inputs could be found")
@@ -69,43 +70,102 @@ func (c *ListenerConfig) Build() (input.Input, error) {
 	return l, nil
 }
 
+// for more informations about the fields, go look at https://github.com/segmentio/kafka-go/blob/master/reader.go#L291
 type KafkaConfig struct {
-	baseInputConfig `mapstructure:",squash"`
-	ID              string   `mapstructure:"client_id,omitempty"`
-	Brokers         []string `mapstructure:"brokers,omitempty"`
-	Topic           string   `mapstructure:"topic,omitempty"`
-	AutoOffsetReset string   `mapstructure:"auto_offset_reset,omitempty"`
-	ConsumerGroup   string   `mapstructure:"consumer_group,omitempty"`
+	baseInputConfig  `mapstructure:",squash"`
+	ID               string        `mapstructure:"client_id,omitempty"`
+	Brokers          []string      `mapstructure:"brokers,omitempty"`
+	Topic            string        `mapstructure:"topic,omitempty"`
+	ConsumerGroupID  string        `mapstructure:"consumer_group_id,omitempty"`
+	QueueCapacity    int           `mapstructure:"queue_capacity,omitempty"`
+	MinBytes         int           `mapstructure:"min_bytes,omitempty"`
+	MaxBytes         int           `mapstructure:"max_bytes,omitempty"`
+	CommitInterval   time.Duration `mapstructure:"commit_interval,omitempty"`
+	SessionTimeout   time.Duration `mapstructure:"session_timeout,omitempty"`
+	RebalanceTimeout time.Duration `mapstructure:"rebalance_timeout,omitempty"`
+	BackoffMin       time.Duration `mapstructure:"backoff_min,omitempty"`
+	BackoffMax       time.Duration `mapstructure:"backoff_max,omitempty"`
+	MaxAttempts      int           `mapstructure:"max_attempts,omitempty"`
+	ReturnErrors     bool          `mapstructure:"return_errors,omitempty"`
 }
 
 func (c *KafkaConfig) Build() (input.Input, error) {
-	// Validate offset
-	var offset int64
-	switch c.AutoOffsetReset {
-	case "newest":
-		offset = sarama.OffsetNewest
-	case "earliest":
-		offset = sarama.OffsetOldest
-	default:
-		return nil, fmt.Errorf(kafkaInvalidAutoOffsetErrorFmt, c.AutoOffsetReset)
-	}
 
-	if len(c.Brokers) == 0 {
+	kafkaConfig := sarama.NewConfig()
+
+	brokers := c.Brokers
+	if brokers == nil || len(brokers) == 0 {
 		return nil, kafkaEmptyBrokersError
 	}
-	if c.ConsumerGroup == "" {
+
+	consumerGroupID := c.ConsumerGroupID
+	if consumerGroupID == "" {
 		return nil, kafkaEmptyConsumerGroupError
 	}
-	if c.Topic == "" {
+
+	topic := c.Topic
+	if topic == "" {
 		return nil, kafkaEmptyTopicError
 	}
+
+	// 0 Mean disabled
+	kafkaConfig.Consumer.Offsets.CommitInterval = c.CommitInterval
+
+	if c.RebalanceTimeout != 0 {
+		kafkaConfig.Consumer.Group.Rebalance.Timeout = c.RebalanceTimeout
+	}
+	if c.SessionTimeout != 0 {
+		kafkaConfig.Consumer.Group.Session.Timeout = c.SessionTimeout
+	}
+	kafkaConfig.Consumer.Return.Errors = c.ReturnErrors
+
+	kafkaConfig.Consumer.Fetch.Min = int32(util.MaxInt(c.MinBytes, 1))
+	kafkaConfig.Consumer.Fetch.Max = int32(c.MaxBytes)
+	kafkaConfig.Consumer.Offsets.Retry.Max = util.MaxInt(c.MaxAttempts, 3)
+	kafkaConfig.Consumer.Group.Rebalance.Retry.Max = util.MaxInt(c.MaxAttempts, 3)
+	kafkaConfig.Consumer.Offsets.Retry.Max = util.MaxInt(c.MaxAttempts, 3)
+
+	backoffMin := c.BackoffMin
+	backoffMax := c.BackoffMax
+
+	if backoffMin == 0 {
+		backoffMin = 100 * time.Millisecond
+	}
+
+	if backoffMax == 0 {
+		backoffMax = 20 * backoffMin
+	}
+
+	if backoffMax < backoffMin {
+		return nil, fmt.Errorf("backoff_max must be not inferior to backoff_min")
+	}
+
+	// Poor's man exponential backoff factor
+	kafkaConfig.Consumer.Retry.BackoffFunc = func(retries int) time.Duration {
+		var ns int64
+		ns = ns << uint(retries)
+		backoffMin := int64(backoffMin)
+		backoffMax := int64(backoffMax)
+		if ns < backoffMin {
+			ns = backoffMin
+		} else if ns > backoffMax {
+			ns = backoffMax
+		}
+		return time.Duration(ns)
+	}
+
+	kafkaConfig.ChannelBufferSize = util.MaxInt(c.QueueCapacity, 1000)
+
+	kafkaConfig.ClientID = c.ID
+
+	kafkaConfig.Consumer.Offsets.Initial = sarama.OffsetNewest
+	kafkaConfig.Version = sarama.V2_2_0_0
 
 	h, err := c.Handler()
 	if err != nil {
 		return nil, fmt.Errorf(handlerErrorFmt, fmt.Sprintf("kafka config: %s", err))
 	}
-	l := input.NewKafka(c.ID, c.Brokers, c.Topic, offset, c.ConsumerGroup, h)
-	return l, nil
+	return input.NewKafka(brokers, topic, consumerGroupID, kafkaConfig, h), nil
 }
 
 func (c *Config) ProcessInputConfig() error {
@@ -115,10 +175,19 @@ func (c *Config) ProcessInputConfig() error {
 	inputs := make([]input.Input, len(c.InputsRaw))
 	for i := 0; i < len(c.InputsRaw); i++ {
 		configMap := c.InputsRaw[i]
+		tRaw, ok := configMap["type"]
+		if !ok {
+			return fmt.Errorf("type must be set")
+		}
+		t, ok := tRaw.(string)
+		if !ok {
+			return fmt.Errorf("type must be a string")
+		}
+
 		var n InputConfig
-		switch configMap["type"].(string) {
+		switch t {
 		case KafkaConfigType:
-			n = &KafkaConfig{AutoOffsetReset: "earliest"}
+			n = &KafkaConfig{}
 		case ListenerConfigType:
 			n = &ListenerConfig{Workers: 1, ReadTimeout: 2 * time.Minute}
 		case "":
@@ -140,11 +209,11 @@ func (c *Config) ProcessInputConfig() error {
 		}
 		err = d.Decode(configMap)
 		if err != nil {
-			return fmt.Errorf(decodingErrorFmt, configMap["type"], err)
+			return fmt.Errorf(decodingErrorFmt, t, err)
 		}
 		l, err := n.Build()
 		if err != nil {
-			return fmt.Errorf(initErrorFmt, configMap["type"], err)
+			return fmt.Errorf(initErrorFmt, t, err)
 		}
 		inputs[i] = l
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -15,3 +15,17 @@ func AddrToPath(s string) string {
 func Key(routeName, addr string) string {
 	return routeName + "_" + AddrToPath(addr)
 }
+
+func MaxInt(x, y int) int {
+	if x < y {
+		return y
+	}
+	return x
+}
+
+func MinInt(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}


### PR DESCRIPTION
Actually tried several implementation of Kafka consuming over a Consumer Group

Sarama is the one providing the best performance by far (kafka-go is sadly battling with a bug that crushes performance), so let's stick with it for now.

TODO: Make a small binary, letting us reset the offsets of the consuming group to a specific date if we were in need to reconsume part of the traffic 

