### PR TITLE
Add initial implementation of metric metadata producer

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -84,6 +84,8 @@ type Route struct {
 
 	Kafka *KafkaRouteConfig
 
+	BgMetadata *BgMetadataRouteConfig `toml:"bg_metadata,omitempty"`
+
 	// Google PubSub
 	Project      string `toml:"project,omitempty"`
 	Format       string `toml:"format,omitempty"`
@@ -117,6 +119,14 @@ type KafkaRouteConfig struct {
 	// FireAndForget bool          `toml:"fire_and_forget,omitempty"` <- This will be the default for now as we don't need any consistency
 	HashBalance   bool `toml:"hashing_balancing,omitempty"`
 	QueueCapacity int  `toml:"queue_capacity,omitempty"`
+}
+
+type BgMetadataRouteConfig struct {
+	// TODO Add option to configure all bloom filter parameters
+	// TODO Add additional configuration to for cassandra
+	ShardingFactor int     `toml:"sharding_factor,omitempty"` // number of shards handling metrics
+	FilterSize     uint    `toml:"filter_size,omitempty"`     // max total number of metrics
+	FaultTolerance float64 `toml:"fault_tolerance,omitempty"` // value 0.0 - 1.0
 }
 
 type Rewriter struct {

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -127,6 +127,8 @@ type BgMetadataRouteConfig struct {
 	ShardingFactor int     `toml:"sharding_factor,omitempty"` // number of shards handling metrics
 	FilterSize     uint    `toml:"filter_size,omitempty"`     // max total number of metrics
 	FaultTolerance float64 `toml:"fault_tolerance,omitempty"` // value 0.0 - 1.0
+	ClearInterval  string  `toml:"clear_interval,omitempty"`  // frequency of filter clearing
+	ClearWait      string  `toml:"clear_wait,omitempty"`      // wait time between each filter clear
 }
 
 type Rewriter struct {

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -129,6 +129,7 @@ type BgMetadataRouteConfig struct {
 	FaultTolerance float64 `toml:"fault_tolerance,omitempty"` // value 0.0 - 1.0
 	ClearInterval  string  `toml:"clear_interval,omitempty"`  // frequency of filter clearing
 	ClearWait      string  `toml:"clear_wait,omitempty"`      // wait time between each filter clear
+	Cache          string  `toml:"cache,omitempty"`           // location of filter storage on disk; feature not enabled if path not provided
 }
 
 type Rewriter struct {

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -128,7 +128,7 @@ type BgMetadataRouteConfig struct {
 	FilterSize     uint    `toml:"filter_size,omitempty"`     // max total number of metrics
 	FaultTolerance float64 `toml:"fault_tolerance,omitempty"` // value 0.0 - 1.0
 	ClearInterval  string  `toml:"clear_interval,omitempty"`  // frequency of filter clearing
-	ClearWait      string  `toml:"clear_wait,omitempty"`      // wait time between each filter clear
+	ClearWait      string  `toml:"clear_wait,omitempty"`      // wait time between each filter clear. defaults to clear_wait/sharding_factor
 	Cache          string  `toml:"cache,omitempty"`           // location of filter storage on disk; feature not enabled if path not provided
 }
 

--- a/examples/bg_metadata.toml
+++ b/examples/bg_metadata.toml
@@ -19,3 +19,4 @@ type = 'bg_metadata'
     sharding_factor = 100
     filter_size = 1000000
     fault_tolerance = 0.0000001
+    clear_interval = "60s"

--- a/examples/bg_metadata.toml
+++ b/examples/bg_metadata.toml
@@ -20,3 +20,4 @@ type = 'bg_metadata'
     filter_size = 1000000
     fault_tolerance = 0.0000001
     clear_interval = "60s"
+    cache = "/tmp/carbon-relay-ng/cache"

--- a/examples/bg_metadata.toml
+++ b/examples/bg_metadata.toml
@@ -1,0 +1,21 @@
+instance = "${HOST}"
+
+log_level = "info"
+admin_addr = "0.0.0.0:2004"
+http_addr = "0.0.0.0:8081"
+bad_metrics_max_age = "24h"
+
+[[inputs]]
+type = "listener"
+format = "plain"
+listen_addr = "127.0.0.1:4000"
+read_timeout = "120s"
+workers = 5
+
+[[route]]
+key = 'criteo'
+type = 'bg_metadata'
+    [route.bg_metadata]
+    sharding_factor = 100
+    filter_size = 1000000
+    fault_tolerance = 0.0000001

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,6 @@ require (
 	github.com/kisielk/og-rek v1.0.0
 	github.com/libp2p/go-reuseport v0.0.0-20190411201116-b72b23b78b80
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
@@ -34,6 +32,8 @@ require (
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/taylorchu/toki v0.0.0-20141019163204-20e86122596c
 	github.com/valyala/fastrand v1.0.0
+	github.com/willf/bitset v1.1.10 // indirect
+	github.com/willf/bloom v2.0.3+incompatible
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/frankban/quicktest v1.4.1 // indirect
-	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/google/go-cmp v0.3.1
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/jcmturner/gofork v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,10 @@ github.com/taylorchu/toki v0.0.0-20141019163204-20e86122596c h1:FPVNYOiTjaGNfDYe
 github.com/taylorchu/toki v0.0.0-20141019163204-20e86122596c/go.mod h1:YYyjUTaSaC2W8KSnbqKGHDKPd/e/8c88su0LP0NkUfk=
 github.com/valyala/fastrand v1.0.0 h1:LUKT9aKer2dVQNUi3waewTbKV+7H17kvWFNKs2ObdkI=
 github.com/valyala/fastrand v1.0.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
+github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=
+github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/willf/bloom v2.0.3+incompatible h1:QDacWdqcAUI1MPOwIQZRy9kOR7yxfyEmxX8Wdm2/JPA=
+github.com/willf/bloom v2.0.3+incompatible/go.mod h1:MmAltL9pDMNTrvUkxdg0k0q5I0suxmuwp3KbyrZLOZ8=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=

--- a/metrics/bgmetadata_metrics.go
+++ b/metrics/bgmetadata_metrics.go
@@ -1,0 +1,34 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type BgMetadataMetrics struct {
+	AddedMetrics    prometheus.Counter
+	FilteredMetrics prometheus.Counter
+}
+
+const bgMetadataNamespace = "metadata"
+
+func NewBgMetadataMetrics(id string) BgMetadataMetrics {
+	namespace := bgMetadataNamespace
+	mm := BgMetadataMetrics{}
+	labels := prometheus.Labels{
+		"id": id,
+	}
+	mm.AddedMetrics = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace:   namespace,
+		Name:        "added_metrics_total",
+		Help:        "total number of metrics added to metadata",
+		ConstLabels: labels,
+	})
+	mm.FilteredMetrics = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace:   namespace,
+		Name:        "filtered_metrics_total",
+		Help:        "total number of metrics filtered from adding to metadata",
+		ConstLabels: labels,
+	})
+	return mm
+}

--- a/route/bgmetadata.go
+++ b/route/bgmetadata.go
@@ -38,7 +38,7 @@ type BgMetadata struct {
 }
 
 // NewBloomFilterConfig creates a new BloomFilterConfig
-func NewBloomFilterConfig(n uint, p float64, shardingFactor int, clearInterval, clearWait time.Duration) (*BloomFilterConfig, error) {
+func NewBloomFilterConfig(n uint, p float64, shardingFactor int, clearInterval, clearWait time.Duration) (BloomFilterConfig, error) {
 	bfc := BloomFilterConfig{
 		n:              n,
 		p:              p,
@@ -53,15 +53,15 @@ func NewBloomFilterConfig(n uint, p float64, shardingFactor int, clearInterval, 
 		bfc.clearWait = clearInterval / time.Duration(shardingFactor)
 		bfc.logger.Debug("overiding clear_wait value", zap.Duration("clear_wait", bfc.clearWait))
 	}
-	return &bfc, nil
+	return bfc, nil
 }
 
 // NewBgMetadataRoute creates BgMetadata, starts sharding and filtering incoming metrics.
-func NewBgMetadataRoute(key, prefix, sub, regex string, bfCfg *BloomFilterConfig) (*BgMetadata, error) {
+func NewBgMetadataRoute(key, prefix, sub, regex string, bfCfg BloomFilterConfig) (*BgMetadata, error) {
 	m := BgMetadata{
 		baseRoute: *newBaseRoute(key, "bg_metadata"),
 		shards:    make([]shard, bfCfg.shardingFactor),
-		bfCfg:     *bfCfg,
+		bfCfg:     bfCfg,
 	}
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 	// init every shard with filter

--- a/route/bgmetadata.go
+++ b/route/bgmetadata.go
@@ -1,0 +1,108 @@
+package route
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"sync"
+
+	"github.com/graphite-ng/carbon-relay-ng/encoding"
+	"github.com/graphite-ng/carbon-relay-ng/matcher"
+	"github.com/willf/bloom"
+)
+
+type BloomFilterConfig struct {
+	N uint
+	P float64
+}
+
+type BgMetadata struct {
+	baseRoute
+	metricChannels []chan []byte
+	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+}
+
+func NewBgMetadataRoute(key, prefix, sub, regex string, shards int, bloomFilterCfg *BloomFilterConfig) (*BgMetadata, error) {
+	m := BgMetadata{
+		baseRoute: *newBaseRoute(key, "bg_metadata"),
+	}
+	// create a channel for every shard
+	m.metricChannels = make([]chan []byte, shards)
+	for shard := range m.metricChannels {
+		m.metricChannels[shard] = make(chan []byte, 500)
+	}
+	// create context
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	// start goroutines to handle metric filtering
+	for shard, ch := range m.metricChannels {
+		go m.handleMetric(m.ctx, ch, shard, bloomFilterCfg)
+	}
+
+	// matcher required to initialise route.Config for routing table
+	// othewise it will panic
+	mt, err := matcher.New(prefix, sub, regex)
+	if err != nil {
+		return nil, err
+	}
+	m.config.Store(baseConfig{*mt, nil})
+
+	return &m, nil
+}
+
+func (m *BgMetadata) handleMetric(ctx context.Context, ch chan []byte, shard int, bloomFilterCfg *BloomFilterConfig) {
+	m.wg.Add(1)
+	defer m.wg.Done()
+	m.logger.Debug(fmt.Sprintf("starting metric handler for shard %d", shard+1))
+	// init bloom filter
+	bloomFilter := bloom.NewWithEstimates(bloomFilterCfg.N, bloomFilterCfg.P)
+	// read from channel and fill filter
+	for {
+		select {
+		case <-ctx.Done():
+			// close channel when done
+			close(ch)
+			return
+		case metric := <-ch:
+			// add to bloom filter if not there already
+			if !bloomFilter.Test(metric) {
+				bloomFilter.Add(metric)
+				// increase outgoing metric prometheus counter
+				m.rm.OutMetrics.Inc()
+				// do nothing for now
+				m.logger.Debug(fmt.Sprintf("adding metric to metadata: %s", string(metric)))
+			} else {
+				// don't output metrics already in the filter
+				m.logger.Debug(fmt.Sprintf("skipping metric: %s", string(metric)))
+			}
+		}
+	}
+}
+
+func getChannelNum(metricName string, chLength int) uint32 {
+	return crc32.Checksum([]byte(metricName), crc32.MakeTable(crc32.IEEE)) % uint32(chLength)
+}
+
+func (m *BgMetadata) Shutdown() error {
+	// start close and cleanup of everything here; and return err
+	m.logger.Info("shutting down bg_metadata")
+	m.cancel()
+	m.logger.Debug("waiting for goroutines")
+	m.wg.Wait()
+	return nil
+}
+
+func (m *BgMetadata) Dispatch(dp encoding.Datapoint) {
+	// increase incoming metric prometheus counter
+	m.rm.InMetrics.Inc()
+	// crc32 mod shard number
+	chNum := getChannelNum(dp.Name, len(m.metricChannels))
+	// put metric in channels handled in goroutines
+	m.metricChannels[chNum] <- []byte(dp.Name)
+	return
+}
+
+func (m *BgMetadata) Snapshot() Snapshot {
+	return makeSnapshot(&m.baseRoute)
+}

--- a/route/bgmetadata.go
+++ b/route/bgmetadata.go
@@ -178,9 +178,11 @@ func (m *BgMetadata) clearBloomFilter() {
 					return
 				default:
 					sh.lock.Lock()
-					err := sh.saveShardState(m.bfCfg.Cache)
-					if err != nil {
-						m.logger.Error("cannot save shard state to filesystem", zap.Error(err))
+					if m.bfCfg.Cache != "" {
+						err := sh.saveShardState(m.bfCfg.Cache)
+						if err != nil {
+							m.logger.Error("cannot save shard state to filesystem", zap.Error(err))
+						}
 					}
 					m.logger.Debug("clearing filter for shard", zap.Int("shard_number", i+1))
 					sh.filter.ClearAll()

--- a/route/bgmetadata_test.go
+++ b/route/bgmetadata_test.go
@@ -1,0 +1,71 @@
+package route
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/graphite-ng/carbon-relay-ng/encoding"
+	"github.com/stretchr/testify/assert"
+)
+
+func testBloomFilterConfig() BloomFilterConfig {
+	const (
+		shardingFactor = 3
+		filterSize     = 1000000
+		faultTolerance = 0.0000001
+		clearInterval  = time.Duration(300 * time.Millisecond)
+		cache          = "" // don't test caching
+	)
+	var clearWait time.Duration
+	bfc, _ := NewBloomFilterConfig(
+		filterSize,
+		faultTolerance,
+		shardingFactor,
+		cache,
+		clearInterval,
+		clearWait,
+	)
+	return bfc
+}
+
+func testBgMetadata(t *testing.T) *BgMetadata {
+	const (
+		key    = "test_route"
+		prefix = ""
+		sub    = ""
+		regex  = ""
+	)
+	bfc := testBloomFilterConfig()
+	m, _ := NewBgMetadataRoute(key, prefix, sub, regex, bfc)
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	return m
+}
+
+func TestMetricFiltering(t *testing.T) {
+	m := testBgMetadata(t)
+	dp := make([]encoding.Datapoint, m.bfCfg.ShardingFactor)
+	dp[0] = encoding.Datapoint{Name: "metric.name.aaaa"}      // 0
+	dp[1] = encoding.Datapoint{Name: "metric.name.aaaaaaaaa"} // 1
+	dp[2] = encoding.Datapoint{Name: "metric.name.bbbb"}      // 2
+
+	// check if right filters are filled
+	for i := 0; i < len(dp); i++ {
+		m.Dispatch(dp[i])
+		assert.True(t, m.shards[i].filter.TestString(dp[i].Name))
+	}
+	m.Dispatch(dp[0])
+
+	// check if added metrics are cleared from the filters
+	go m.clearBloomFilter()
+	time.Sleep(1 * time.Second)
+	m.Shutdown()
+	for i := 0; i < len(dp); i++ {
+		assert.False(t, m.shards[i].filter.TestString(dp[i].Name))
+	}
+}
+
+func TestClearWaitDefaultValue(t *testing.T) {
+	bfc := testBloomFilterConfig()
+	assert.Equal(t, bfc.ClearWait, bfc.ClearInterval/time.Duration(bfc.ShardingFactor))
+}

--- a/route/bgmetadata_test.go
+++ b/route/bgmetadata_test.go
@@ -14,7 +14,7 @@ func testBloomFilterConfig() BloomFilterConfig {
 		shardingFactor = 3
 		filterSize     = 1000000
 		faultTolerance = 0.0000001
-		clearInterval  = time.Duration(300 * time.Millisecond)
+		clearInterval  = time.Duration(10 * time.Millisecond)
 		cache          = "" // don't test caching
 	)
 	var clearWait time.Duration
@@ -58,7 +58,7 @@ func TestMetricFiltering(t *testing.T) {
 
 	// check if added metrics are cleared from the filters
 	go m.clearBloomFilter()
-	time.Sleep(1 * time.Second)
+	time.Sleep(30 * time.Millisecond)
 	m.Shutdown()
 	for i := 0; i < len(dp); i++ {
 		assert.False(t, m.shards[i].filter.TestString(dp[i].Name))

--- a/table/table.go
+++ b/table/table.go
@@ -780,6 +780,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				bgMetadataCfg.FilterSize,
 				bgMetadataCfg.FaultTolerance,
 				bgMetadataCfg.ShardingFactor,
+				bgMetadataCfg.Cache,
 				clearInterval,
 				clearWait,
 			)

--- a/table/table.go
+++ b/table/table.go
@@ -777,8 +777,11 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 			}
 
 			bloomFilterCfg := &route.BloomFilterConfig{
-				N: bgMetadataCfg.FilterSize,
-				P: bgMetadataCfg.FaultTolerance,
+				N:              bgMetadataCfg.FilterSize,
+				P:              bgMetadataCfg.FaultTolerance,
+				ShardingFactor: bgMetadataCfg.ShardingFactor,
+				ClearInterval:  clearInterval,
+				ClearWait:      clearWait,
 			}
 
 			route, err := route.NewBgMetadataRoute(
@@ -786,9 +789,6 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				routeConfig.Prefix,
 				routeConfig.Substr,
 				routeConfig.Regex,
-				bgMetadataCfg.ShardingFactor,
-				clearInterval,
-				clearWait,
 				bloomFilterCfg,
 			)
 			if err != nil {

--- a/table/table.go
+++ b/table/table.go
@@ -776,12 +776,15 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("error adding route '%s': clear wait value must be less than clear_interval / sharding_factor", routeConfig.Key)
 			}
 
-			bloomFilterCfg := &route.BloomFilterConfig{
-				N:              bgMetadataCfg.FilterSize,
-				P:              bgMetadataCfg.FaultTolerance,
-				ShardingFactor: bgMetadataCfg.ShardingFactor,
-				ClearInterval:  clearInterval,
-				ClearWait:      clearWait,
+			bloomFilterConfig, err := route.NewBloomFilterConfig(
+				bgMetadataCfg.FilterSize,
+				bgMetadataCfg.FaultTolerance,
+				bgMetadataCfg.ShardingFactor,
+				clearInterval,
+				clearWait,
+			)
+			if err != nil {
+				return fmt.Errorf("error adding route '%s': %s", routeConfig.Key, err)
 			}
 
 			route, err := route.NewBgMetadataRoute(
@@ -789,7 +792,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				routeConfig.Prefix,
 				routeConfig.Substr,
 				routeConfig.Regex,
-				bloomFilterCfg,
+				bloomFilterConfig,
 			)
 			if err != nil {
 				return fmt.Errorf("error adding route '%s': %s", routeConfig.Key, err)

--- a/table/table.go
+++ b/table/table.go
@@ -767,9 +767,12 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("error adding route '%s': could not parse clear_interval", routeConfig.Key)
 			}
 
-			clearWait, err := time.ParseDuration(bgMetadataCfg.ClearWait)
-			if err != nil && bgMetadataCfg.ClearWait != "" {
-				return fmt.Errorf("error adding route '%s': could not parse clear_wait", routeConfig.Key)
+			var clearWait time.Duration
+			if bgMetadataCfg.ClearWait != "" {
+				clearWait, err = time.ParseDuration(bgMetadataCfg.ClearWait)
+				if err != nil {
+					return fmt.Errorf("error adding route '%s': could not parse clear_wait", routeConfig.Key)
+				}
 			}
 
 			if clearWait > clearInterval/time.Duration(bgMetadataCfg.ShardingFactor) {

--- a/table/table.go
+++ b/table/table.go
@@ -754,7 +754,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 			if bgMetadataCfg.FaultTolerance == 0 {
 				return fmt.Errorf("error adding route '%s': fault tolerance percentage must be specified", routeConfig.Key)
 			}
-			if bgMetadataCfg.FaultTolerance < 0 || bgMetadataCfg.FaultTolerance > 1 {
+			if bgMetadataCfg.FaultTolerance <= 0 || bgMetadataCfg.FaultTolerance >= 1 {
 				return fmt.Errorf("error adding route '%s': fault tolerance value must be between 0 and 1", routeConfig.Key)
 			}
 

--- a/table/table.go
+++ b/table/table.go
@@ -767,6 +767,8 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("error adding route '%s': could not parse clear_interval", routeConfig.Key)
 			}
 
+			// clearWait is not required, so it's only parsed if it's defined
+			// if undefined, it's set to clearInterval/ShardingFactor as default
 			var clearWait time.Duration
 			if bgMetadataCfg.ClearWait != "" {
 				clearWait, err = time.ParseDuration(bgMetadataCfg.ClearWait)


### PR DESCRIPTION
* Initial component required to store metric names in Cassandra
* Utilizes a bloom filter to send only new metrics
* Logs actions and errors according to severity
* Periodically progressively clear filters bloom filter state
* Use prometheus metrics to measure added/filtered metrics
* Store filter state somewhere and load state on app restart to prevent bursting of already known metrics
* Tests for basic filtering functionality

Todo:
* Introduce rate limiting and send metric in batch instead of one by one