### PR TITLE
enable several servers for elasticsearch storage

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -137,13 +137,13 @@ type BgMetadataRouteConfig struct {
 }
 
 type BgMetadataESConfig struct {
-	StorageServer string `toml:"storage_server,omitempty"`
-	BulkSize      uint   `toml:"bulk_size,omitempty,default=1"`
-	Username      string `toml:"username,omitempty"`
-	Password      string `toml:"password,omitempty"`
-	IndexName     string `toml:"index_name,omitempty"`     // index prefix, will be appended with date
-	IndexDateFmt  string `toml:"index_date_fmt,omitempty"` // strftime string, date will be formated using this then appended to index
-	MaxRetry      uint   `toml:"max_retry,omitempty"`
+	StorageServers []string `toml:"storage_servers,omitempty"`
+	BulkSize       uint     `toml:"bulk_size,omitempty,default=1"`
+	Username       string   `toml:"username,omitempty"`
+	Password       string   `toml:"password,omitempty"`
+	IndexName      string   `toml:"index_name,omitempty"`     // index prefix, will be appended with date
+	IndexDateFmt   string   `toml:"index_date_fmt,omitempty"` // strftime string, date will be formated using this then appended to index
+	MaxRetry       uint     `toml:"max_retry,omitempty"`
 }
 
 type Rewriter struct {

--- a/docs/config.md
+++ b/docs/config.md
@@ -273,7 +273,7 @@ storage                     |     N     |  string     | ""            |  Storage
 
 setting                     | mandatory | values      | default       | description 
 ----------------------------|-----------|-------------|---------------|------------
-storage_server              |     Y     |  string     | N/A           | address of ES server to use 
+storage_servers              |     Y     |  []string     | N/A           | addresses of ES servers to use 
 bulk_size                   |     Y     |  uint       | N/A           | Maximum number of metrics metadata that can be bulk sent at once
 username                    |     N     |  string     | ""            | let empty if no authentication
 password                    |     N     |  string     | ""            | let empty if no authentication
@@ -298,7 +298,7 @@ type = 'bg_metadata'
     storage_aggregations = "storage-aggregation.conf"
     storage = "elasticsearch"
         [route.bg_metadata.elasticsearch]
-        storage_server = "http://elasticsearch:9200"
+        storage_server = ["http://elasticsearch:9200"]
         bulk_size = 10000
         index_name = "metrics"
         username = "user"

--- a/storage/elasticsearch_metadata.go
+++ b/storage/elasticsearch_metadata.go
@@ -167,13 +167,11 @@ func newBgMetadataElasticSearchConnector(elasticSearchClient ElasticSearchClient
 	return &esc
 }
 
-func createElasticSearchClient(server, username, password string) (*elasticsearch.Client, error) {
+func createElasticSearchClient(servers []string, username, password string) (*elasticsearch.Client, error) {
 	cfg := elasticsearch.Config{
-		Addresses: []string{
-			server,
-		},
-		Username: username,
-		Password: password,
+		Addresses: servers,
+		Username:  username,
+		Password:  password,
 	}
 
 	es, err := elasticsearch.NewClient(cfg)
@@ -190,7 +188,7 @@ func createElasticSearchClient(server, username, password string) (*elasticsearc
 
 // NewBgMetadataElasticSearchConnectorWithDefaults is the public contructor of BgMetadataElasticSearchConnector
 func NewBgMetadataElasticSearchConnectorWithDefaults(cfg *cfg.BgMetadataESConfig) *BgMetadataElasticSearchConnector {
-	es, err := createElasticSearchClient(cfg.StorageServer, cfg.Username, cfg.Password)
+	es, err := createElasticSearchClient(cfg.StorageServers, cfg.Username, cfg.Password)
 
 	if err != nil {
 		log.Fatalf("Could not create ElasticSearch connector: %v", err)

--- a/storage/elasticsearch_metadata_test.go
+++ b/storage/elasticsearch_metadata_test.go
@@ -223,7 +223,7 @@ func BenchmarkWritesWithBulkSize100(b *testing.B) {
 func GetClient() (*elasticsearch.Client, error) {
 	if es == nil {
 		fmt.Printf("creating\n")
-		es, err := createElasticSearchClient("http://localhost:9200", "", "")
+		es, err := createElasticSearchClient([]string{"http://localhost:9200"}, "", "")
 		return es, err
 	}
 	fmt.Printf("cache\n")

--- a/table/table.go
+++ b/table/table.go
@@ -800,7 +800,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				if bgMetadataCfg.ESConfig == nil {
 					return fmt.Errorf("error adding route '%s': ElasticSearch configuration is needed", routeConfig.Key)
 				}
-				if bgMetadataCfg.ESConfig.StorageServer == "" {
+				if len(bgMetadataCfg.ESConfig.StorageServers) == 0 {
 					return fmt.Errorf("error adding route '%s': undefined storage server", routeConfig.Key)
 				}
 				if bgMetadataCfg.ESConfig.BulkSize == 0 {


### PR DESCRIPTION
To prevent having only one storage server defined, changed the configuration from a string to a []string