### PR TITLE
Typo: Fixing old config variable to new name.

### DIFF
--- a/docker/carbon-relay-ng-kafka-io/config/kafka-input.toml
+++ b/docker/carbon-relay-ng-kafka-io/config/kafka-input.toml
@@ -50,6 +50,6 @@ type = 'bg_metadata'
     storage_aggregations = "/config/storage-aggregation.conf"
     storage = "elasticsearch"
         [route.bg_metadata.elasticsearch]
-        storage_server = "http://elasticsearch:9200"
+        storage_servers = ["http://elasticsearch:9200"]
         bulk_size = 2
         max_retry = 1

--- a/docs/config.md
+++ b/docs/config.md
@@ -300,7 +300,7 @@ type = 'bg_metadata'
     storage_aggregations = "storage-aggregation.conf"
     storage = "elasticsearch"
         [route.bg_metadata.elasticsearch]
-        storage_server = ["http://elasticsearch:9200"]
+        storage_servers = ["http://elasticsearch:9200"]
         bulk_size = 10000
         index_name = "bg"
         username = "user"

--- a/examples/bg_metadata.toml
+++ b/examples/bg_metadata.toml
@@ -25,7 +25,7 @@ type = 'bg_metadata'
     storage_aggregations = "/tmp/storage-aggregation.conf"
     storage = "elasticsearch"
     [route.bg_metadata.elasticsearch]
-        storage_server = "http://localhost:9200"
+        storage_servers = ["http://localhost:9200"]
         bulk_size = 10000
 
 [[route]]


### PR DESCRIPTION
The new setting is now `storage_servers`, no longer `storage_server`.