### PR TITLE
Saving bloom filters state in cache files.

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -129,6 +129,7 @@ type BgMetadataRouteConfig struct {
 	FaultTolerance           float64             `toml:"fault_tolerance,omitempty"` // value 0.0 - 1.0
 	ClearInterval            string              `toml:"clear_interval,omitempty"`  // frequency of filter clearing
 	ClearWait                string              `toml:"clear_wait,omitempty"`      // wait time between each filter clear. defaults to clear_wait/sharding_factor
+	SaveInterval             string              `toml:"save_interval,omitempty"`   // frequency of filter saving
 	Cache                    string              `toml:"cache,omitempty"`           // location of filter storage on disk; feature not enabled if path not provided
 	StorageAggregationConfig string              `toml:"storage_aggregations,omitempty"`
 	StorageSchemasConfig     string              `toml:"storage_schemas,omitempty"`

--- a/docker/carbon-relay-ng-kafka-io/config/kafka-input.toml
+++ b/docker/carbon-relay-ng-kafka-io/config/kafka-input.toml
@@ -45,6 +45,7 @@ type = 'bg_metadata'
     filter_size = 1000
     fault_tolerance = 0.0000001
     clear_interval = "60s"
+    save_interval = "30s"
     cache = "/tmp/"
     storage_schemas = "/config/storage-schemas.conf"
     storage_aggregations = "/config/storage-aggregation.conf"

--- a/docs/config.md
+++ b/docs/config.md
@@ -262,7 +262,7 @@ filter_size                 |     Y     |  uint       | N/A           |  max tot
 fault_tolerance             |     Y     |  float      | N/A           |  transparent, value between 0.0 and 1.0
 clear_interval              |     Y     |  string     | N/A           |  frequency of filter clearing (all shards) do not set if clear_wait
 clear_wait                  |     Y     |  string     | N/A           |  wait time between each filter clear. defaults to clear_interval/sharding_factor
-save_interval               |     Y     |  string     | N/A           |  filter saving for all shards frequency
+save_interval               |     N     |  string     | "360s"        |  filter saving for all shards frequency (default: 5 min)
 storage_aggregations        |     Y     |  string     | N/A           |  biggraphite formated aggregation config path
 storage_schemas             |     Y     |  string     | N/A           |  biggraphite formated schemas config path 
 storage                     |     N     |  string     | ""            |  Storage backend to use either "cassandra" or "elasticsearch" 

--- a/docs/config.md
+++ b/docs/config.md
@@ -262,6 +262,7 @@ filter_size                 |     Y     |  uint       | N/A           |  max tot
 fault_tolerance             |     Y     |  float      | N/A           |  transparent, value between 0.0 and 1.0
 clear_interval              |     Y     |  string     | N/A           |  frequency of filter clearing (all shards) do not set if clear_wait
 clear_wait                  |     Y     |  string     | N/A           |  wait time between each filter clear. defaults to clear_interval/sharding_factor
+save_interval               |     Y     |  string     | N/A           |  filter saving for all shards frequency
 storage_aggregations        |     Y     |  string     | N/A           |  biggraphite formated aggregation config path
 storage_schemas             |     Y     |  string     | N/A           |  biggraphite formated schemas config path 
 storage                     |     N     |  string     | ""            |  Storage backend to use either "cassandra" or "elasticsearch" 
@@ -295,6 +296,7 @@ type = 'bg_metadata'
     filter_size = 1000
     fault_tolerance = 0.0000001
     clear_interval = "60s"
+    save_interval = "30s"
     cache = "/tmp/carbon-relay-ng/cache"
     storage_schemas = "storage-schemas.conf"
     storage_aggregations = "storage-aggregation.conf"

--- a/examples/bg_metadata.toml
+++ b/examples/bg_metadata.toml
@@ -20,6 +20,7 @@ type = 'bg_metadata'
     filter_size = 1000000
     fault_tolerance = 0.0000001
     clear_interval = "60s"
+    save_interval = "30s"
     cache = "/tmp/carbon-relay-ng/cache"
     storage_schemas = "/tmp/storage-schemas.conf"
     storage_aggregations = "/tmp/storage-aggregation.conf"

--- a/route/bgmetadata_test.go
+++ b/route/bgmetadata_test.go
@@ -16,6 +16,7 @@ func testBloomFilterConfig() BloomFilterConfig {
 		filterSize     = 1000000
 		faultTolerance = 0.0000001
 		clearInterval  = time.Duration(10 * time.Millisecond)
+		saveInterval   = time.Duration(10 * time.Millisecond)
 		cache          = "" // don't test caching
 	)
 	var clearWait time.Duration
@@ -26,6 +27,7 @@ func testBloomFilterConfig() BloomFilterConfig {
 		cache,
 		clearInterval,
 		clearWait,
+		saveInterval,
 	)
 	return bfc
 }

--- a/table/table.go
+++ b/table/table.go
@@ -26,6 +26,10 @@ import (
 	"github.com/graphite-ng/carbon-relay-ng/route"
 )
 
+const (
+	default_save_interval = "360s"
+)
+
 type TableConfig struct {
 	rewriters   []rewriter.RW
 	aggregators []*aggregator.Aggregator
@@ -774,7 +778,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 			}
 
 			if bgMetadataCfg.SaveInterval == "" {
-				return fmt.Errorf("error adding route '%s': save interval value must be specified", routeConfig.Key)
+				bgMetadataCfg.SaveInterval = default_save_interval
 			}
 
 			clearInterval, err := time.ParseDuration(bgMetadataCfg.ClearInterval)

--- a/table/table.go
+++ b/table/table.go
@@ -773,9 +773,18 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("error adding route '%s': clear interval value must be specified", routeConfig.Key)
 			}
 
+			if bgMetadataCfg.SaveInterval == "" {
+				return fmt.Errorf("error adding route '%s': save interval value must be specified", routeConfig.Key)
+			}
+
 			clearInterval, err := time.ParseDuration(bgMetadataCfg.ClearInterval)
 			if err != nil {
 				return fmt.Errorf("error adding route '%s': could not parse clear_interval", routeConfig.Key)
+			}
+
+			saveInterval, err := time.ParseDuration(bgMetadataCfg.SaveInterval)
+			if err != nil {
+				return fmt.Errorf("error adding route '%s': could not parse save_interval", routeConfig.Key)
 			}
 
 			// clearWait is not required, so it's only parsed if it's defined
@@ -817,6 +826,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				bgMetadataCfg.Cache,
 				clearInterval,
 				clearWait,
+				saveInterval,
 			)
 			if err != nil {
 				return fmt.Errorf("error adding route '%s': %s", routeConfig.Key, err)


### PR DESCRIPTION
Bloom filters will now be regurlarly saved on disk according the new mandatory
save_interval setting. Before saving each filters, check if they are empty and
delete state files if so. Cleared bloom filters will also have their state file
deleted as well.