### PR TITLE
Fixed spool & add a check for dp input

### DIFF
--- a/destination/spool.go
+++ b/destination/spool.go
@@ -99,7 +99,7 @@ func (s *Spool) Reader() {
 			s.logger.Error("failed to dequeue item", zap.Error(err))
 			continue
 		}
-		dp, err := h.Load(i.Value, i.Tags)
+		dp, err := h.Load(i.Value, make(encoding.Tags))
 		if err != nil {
 			s.logger.Error("failed to deserialize datapoint", zap.Error(err))
 			continue
@@ -152,7 +152,7 @@ func (s *Spool) Buffer() {
 			s.sm.Buffer.BufferedMetrics.Dec()
 
 			pre := time.Now()
-			s.queue.Enqueue(dp.AppendToBuf(buf), dp.Tags)
+			s.queue.Enqueue(dp.AppendToBuf(buf))
 			chunk = chunk[:0]
 			s.sm.WriteDuration.Observe(time.Since(pre).Seconds())
 		}

--- a/encoding/datapoint.go
+++ b/encoding/datapoint.go
@@ -20,7 +20,7 @@ func (dp Datapoint) String() string {
 }
 
 func (dp Datapoint) AppendToBuf(buf []byte) (ret []byte) {
-	ret = append(buf, dp.Name...)
+	ret = append(buf, dp.FullName()...)
 	ret = append(ret, ' ')
 	ret = strconv.AppendFloat(ret, dp.Value, 'f', 3, 64)
 	ret = append(ret, ' ')

--- a/encoding/plain.go
+++ b/encoding/plain.go
@@ -20,6 +20,7 @@ var (
 	errEmptyline              = errors.New("empty line")
 	errFmtNullInKey           = "null char at position %d"
 	errFmtNotAscii            = "non-ascii char at position %d"
+	errIncomplete             = "incomplete graphite datapoint"
 )
 
 const PlainFormat FormatName = "plain"
@@ -139,6 +140,11 @@ func (p PlainAdapter) load(msgbuf []byte, tags Tags) (Datapoint, error) {
 		return d, errFieldsNum
 	}
 	firstSpace += start
+
+	if firstSpace == len(msg)-1 {
+		return d, fmt.Errorf(errIncomplete)
+	}
+
 	var err error
 	d.Name, err = p.parseKey(msg[start:firstSpace])
 	if err != nil {
@@ -157,6 +163,11 @@ func (p PlainAdapter) load(msgbuf []byte, tags Tags) (Datapoint, error) {
 		return d, errFieldsNum
 	}
 	nextSpace += firstSpace
+
+	if nextSpace == len(msg)-1 {
+		return d, fmt.Errorf(errIncomplete)
+	}
+
 	v, err := strconv.ParseFloat(msg[firstSpace:nextSpace], 64)
 	if err != nil {
 		return d, err

--- a/encoding/plain_test.go
+++ b/encoding/plain_test.go
@@ -9,10 +9,16 @@ import (
 func TestValidationInvalid(t *testing.T) {
 	h := NewPlain(false)
 	metrics := map[string][]byte{
-		"incorrectFields": []byte("incorrect fields 21300.00 12351123"),
-		"stringValue":     []byte("incorrect_value two 12351123"),
-		"stringTime":      []byte("incorrect_time 1.0 two"),
-	}
+		"incorrectFields":                []byte("incorrect fields 21300.00 12351123"),
+		"stringValue":                    []byte("incorrect_value two 12351123"),
+		"stringTime":                     []byte("incorrect_time 1.0 two"),
+		"incompleteValue":                []byte("incomplete "),
+		"incompleteValueOff":             []byte("   incomplete "),
+		"incompleteValueDot":             []byte(".......incomplete "),
+		"incompleteValueOffNoTrail":      []byte(" incomplete"),
+		"incompleteValueNoTrail":         []byte("incomplete"),
+		"incompleteValueWithValAndTrail": []byte("incomplete 2020 "),
+		"randomBinary":                   []byte("\x10\x68\xcc\x9c\x2c\xa6\x26\xbb\x8a\x1d\x1f\x4d\xfd\x51\xe2\x9e\xd8\xbf\xef\x69\x6b\x60\xaa\x2d\xec\xdf\x23\xb1\xd8\x2c\x1b\x52\x01\x4a\x52\x76\x07\x7f\xb7\xb6")}
 	for test, metric := range metrics {
 		t.Run(test, func(t *testing.T) {
 			_, err := h.load(metric, Tags{})

--- a/queue/item.go
+++ b/queue/item.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"encoding/binary"
-	"github.com/graphite-ng/carbon-relay-ng/encoding"
 )
 
 // var keyPool = sync
@@ -12,7 +11,6 @@ type Item struct {
 	ID    uint64
 	Key   []byte
 	Value []byte
-	Tags  encoding.Tags
 }
 
 func (i *Item) ToString() string {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -4,7 +4,6 @@ package queue
 
 import (
 	"errors"
-	"github.com/graphite-ng/carbon-relay-ng/encoding"
 	"os"
 	"sync"
 
@@ -48,7 +47,7 @@ func OpenQueue(dataDir string, o *opt.Options) (*Queue, error) {
 }
 
 // Enqueue adds an item to the queue.
-func (q *Queue) Enqueue(value []byte, tags encoding.Tags) (*Item, error) {
+func (q *Queue) Enqueue(value []byte) (*Item, error) {
 	q.Lock()
 	defer q.Unlock()
 
@@ -62,7 +61,6 @@ func (q *Queue) Enqueue(value []byte, tags encoding.Tags) (*Item, error) {
 		ID:    q.tail + 1,
 		Key:   encodeID(q.tail + 1),
 		Value: value,
-		Tags:  tags,
 	}
 
 	// Add it to the queue.


### PR DESCRIPTION
- added correctly tags when spooling using FullName
- upon reading dp from spool, correctly allocate a tags map in stead of
dropping it
- when parsing a received plain dp, added a check to prevent panic if
datapoint incomplete