### PR TITLE
register metrics explicitly as we use a custom registry

### DIFF
--- a/metrics/input_metrics.go
+++ b/metrics/input_metrics.go
@@ -11,3 +11,7 @@ var (
 		Help: "The total number of metrics dropped at input",
 	}, []string{"error"})
 )
+
+func registerInputMetrics(registry *SafeRegistry) {
+	registry.MustRegister(DroppedMetrics)
+}

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -32,4 +32,5 @@ func init() {
 	prometheus.DefaultRegisterer = sr
 	prometheus.DefaultGatherer = sr
 	sr.MustRegister(prometheus.NewGoCollector())
+	registerInputMetrics(sr)
 }


### PR DESCRIPTION
We could also get rid of this custom registry. On the commit introducing it there isn't much context on why they changed it in the first place, only that it does not panic on MustRegister