### PR TITLE
supporting metric_suffix/notRegex for Routes

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -1,6 +1,8 @@
 name: Builds and Tests
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -64,6 +64,7 @@ type Route struct {
 	Prefix       string   `toml:"prefix,omitempty"`
 	Substr       string   `toml:"substr,omitempty"`
 	Regex        string   `toml:"regex,omitempty"`
+	NotRegex     string   `toml:"notRegex,omitempty"`
 	Destinations []string `toml:"destinations,omitempty"`
 	MetricSuffix string   `toml:"metric_suffix,omitempty"`
 

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -65,6 +65,7 @@ type Route struct {
 	Substr       string   `toml:"substr,omitempty"`
 	Regex        string   `toml:"regex,omitempty"`
 	Destinations []string `toml:"destinations,omitempty"`
+	MetricSuffix string   `toml:"metric_suffix,omitempty"`
 
 	// grafanaNet & kafkaMdm & Google PubSub
 	SchemasFile  string `toml:"schemas_file,omitempty"`

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -65,8 +65,8 @@ type Destination struct {
 }
 
 // New creates a destination object. Note that it still needs to be told to run via Run().
-func New(routeName, prefix, sub, regex, addr, spoolDir string, spool, pickle bool, periodFlush, periodReConn time.Duration, connBufSize, ioBufSize, spoolBufSize int, spoolMaxBytesPerFile, spoolSyncEvery int64, spoolSyncPeriod, spoolSleep, unspoolSleep time.Duration) (*Destination, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func New(routeName, prefix, sub, regex, notRegex, addr, spoolDir string, spool, pickle bool, periodFlush, periodReConn time.Duration, connBufSize, ioBufSize, spoolBufSize int, spoolMaxBytesPerFile, spoolSyncEvery int64, spoolSyncPeriod, spoolSleep, unspoolSleep time.Duration) (*Destination, error) {
+	m, err := matcher.New(prefix, sub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}
@@ -115,6 +115,7 @@ func (dest *Destination) Update(opts map[string]string) error {
 	prefix := match.Prefix
 	sub := match.Sub
 	regex := match.Regex
+	notRegex := match.NotRegex
 	updateMatcher := false
 	addr := ""
 
@@ -131,6 +132,9 @@ func (dest *Destination) Update(opts map[string]string) error {
 		case "regex":
 			regex = val
 			updateMatcher = true
+		case "notRegex":
+			notRegex = val
+			updateMatcher = true
 		default:
 			return errors.New("no such option: " + name)
 		}
@@ -139,7 +143,7 @@ func (dest *Destination) Update(opts map[string]string) error {
 		dest.updateConn(addr)
 	}
 	if updateMatcher {
-		match, err := matcher.New(prefix, sub, regex)
+		match, err := matcher.New(prefix, sub, regex, notRegex)
 		if err != nil {
 			return err
 		}

--- a/matcher/matcher_test.go
+++ b/matcher/matcher_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func BenchmarkMatchPrefix(b *testing.B) {
-	matcher, _ := New("abcde_fghij.klmnopqrst", "", "")
+	matcher, _ := New("abcde_fghij.klmnopqrst", "", "", "")
 	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
 	for i := 0; i < b.N; i++ {
 		matcher.Match(metric70)
@@ -13,7 +13,7 @@ func BenchmarkMatchPrefix(b *testing.B) {
 }
 
 func BenchmarkMatchSubstr(b *testing.B) {
-	matcher, _ := New("", "1234567890abc", "")
+	matcher, _ := New("", "1234567890abc", "", "")
 	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
 	for i := 0; i < b.N; i++ {
 		matcher.Match(metric70)
@@ -21,9 +21,43 @@ func BenchmarkMatchSubstr(b *testing.B) {
 }
 
 func BenchmarkMatchRegex(b *testing.B) {
-	matcher, _ := New("", "", "abcde_(fghij|foo).[^\\.]+.\\.*.\\.*")
+	matcher, _ := New("", "", "abcde_(fghij|foo).[^\\.]+.\\.*.\\.*", "")
 	metric70 := []byte("abcde_fghij.klmnopqrst.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
 	for i := 0; i < b.N; i++ {
 		matcher.Match(metric70)
+	}
+}
+
+func TestNotRegex(t *testing.T) {
+	matcher, _ := New("", "", "", "counter\\.sum")
+	metric70 := []byte("abcde_fghij.counter.sum.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
+	match := matcher.Match(metric70)
+	if match {
+		t.Errorf("Metric should not match %s %s", metric70, matcher.notRegex)
+	}
+}
+
+func TestSameRegexNotRegex(t *testing.T) {
+	regex := "counter.\\sum"
+	matcher, _ := New("", "", regex, regex)
+	metric70 := []byte("abcde_fghij.counter.sum.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
+	match := matcher.Match(metric70)
+	if match {
+		t.Errorf("Metric %s should match %s, but not match %s,", metric70, matcher.regex, matcher.notRegex)
+	}
+}
+
+func TestRegexNotRegex(t *testing.T) {
+	matcher, _ := New("", "", "toto", "plop")
+	metric70 := []byte("abcde_fghij.toto.uv_wxyz.1234567890abcdefg 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
+	match := matcher.Match(metric70)
+	if !match {
+		t.Errorf("Metric %s should match %s, but not match %s,", metric70, matcher.regex, matcher.notRegex)
+	}
+
+	metric70 = []byte("abcde_fghij.toto.uv_wxyz.plop 12345.6789 1234567890") // key = 48, val = 10, ts = 10 -> 70
+	match = matcher.Match(metric70)
+	if match {
+		t.Errorf("Metric %s should match %s, but not match %s,", metric70, matcher.regex, matcher.notRegex)
 	}
 }

--- a/route/bgmetadata.go
+++ b/route/bgmetadata.go
@@ -82,7 +82,7 @@ func NewBloomFilterConfig(n uint, p float64, shardingFactor int, cache string, c
 
 // NewBgMetadataRoute creates BgMetadata, starts sharding and filtering incoming metrics.
 // additionnalCfg should be nil or *cfg.BgMetadataESConfig if elasticsearch
-func NewBgMetadataRoute(key, prefix, sub, regex, aggregationCfg, schemasCfg string, bfCfg BloomFilterConfig, storageName string, additionnalCfg interface{}, metricSuffix string) (*BgMetadata, error) {
+func NewBgMetadataRoute(key, prefix, sub, regex, notRegex, aggregationCfg, schemasCfg string, bfCfg BloomFilterConfig, storageName string, additionnalCfg interface{}, metricSuffix string) (*BgMetadata, error) {
 	// to make value assignments easier
 	var err error
 
@@ -166,7 +166,7 @@ func NewBgMetadataRoute(key, prefix, sub, regex, aggregationCfg, schemasCfg stri
 	}
 
 	// matcher required to initialise route.Config for routing table, othewise it will panic
-	mt, err := matcher.New(prefix, sub, regex)
+	mt, err := matcher.New(prefix, sub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/route/bgmetadata.go
+++ b/route/bgmetadata.go
@@ -82,12 +82,12 @@ func NewBloomFilterConfig(n uint, p float64, shardingFactor int, cache string, c
 
 // NewBgMetadataRoute creates BgMetadata, starts sharding and filtering incoming metrics.
 // additionnalCfg should be nil or *cfg.BgMetadataESConfig if elasticsearch
-func NewBgMetadataRoute(key, prefix, sub, regex, aggregationCfg, schemasCfg string, bfCfg BloomFilterConfig, storageName string, additionnalCfg interface{}) (*BgMetadata, error) {
+func NewBgMetadataRoute(key, prefix, sub, regex, aggregationCfg, schemasCfg string, bfCfg BloomFilterConfig, storageName string, additionnalCfg interface{}, metricSuffix string) (*BgMetadata, error) {
 	// to make value assignments easier
 	var err error
 
 	m := BgMetadata{
-		baseRoute:         *newBaseRoute(key, "bg_metadata"),
+		baseRoute:         *newBaseRoute(key, "bg_metadata", metricSuffix),
 		shards:            make([]shard, bfCfg.ShardingFactor),
 		bfCfg:             bfCfg,
 		metricDirectories: make(chan string),
@@ -374,6 +374,9 @@ func (m *BgMetadata) Shutdown() error {
 func (m *BgMetadata) Dispatch(dp encoding.Datapoint) {
 	// increase incoming metric prometheus counter
 	m.rm.InMetrics.Inc()
+	if m.metricSuffix != "" {
+		dp.Name += m.metricSuffix
+	}
 	if !m.testStringAndAdd(dp.Name) {
 		m.mm.AddedMetrics.Inc()
 		m.DispatchDirectory(dp)

--- a/route/bgmetadata_test.go
+++ b/route/bgmetadata_test.go
@@ -34,15 +34,16 @@ func testBloomFilterConfig() BloomFilterConfig {
 
 func testBgMetadata(t *testing.T) *BgMetadata {
 	const (
-		key    = "test_route"
-		prefix = ""
-		sub    = ""
-		regex  = ""
-		sch    = "../examples/storage-schemas.conf"
-		agg    = "../examples/storage-aggregation.conf"
+		key      = "test_route"
+		prefix   = ""
+		sub      = ""
+		regex    = ""
+		notRegex = ""
+		sch      = "../examples/storage-schemas.conf"
+		agg      = "../examples/storage-aggregation.conf"
 	)
 	bfc := testBloomFilterConfig()
-	m, _ := NewBgMetadataRoute(key, prefix, sub, regex, agg, sch, bfc, "testing", nil, "")
+	m, _ := NewBgMetadataRoute(key, prefix, sub, regex, notRegex, agg, sch, bfc, "testing", nil, "")
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 	return m
 }

--- a/route/bgmetadata_test.go
+++ b/route/bgmetadata_test.go
@@ -42,7 +42,7 @@ func testBgMetadata(t *testing.T) *BgMetadata {
 		agg    = "../examples/storage-aggregation.conf"
 	)
 	bfc := testBloomFilterConfig()
-	m, _ := NewBgMetadataRoute(key, prefix, sub, regex, agg, sch, bfc, "testing", nil)
+	m, _ := NewBgMetadataRoute(key, prefix, sub, regex, agg, sch, bfc, "testing", nil, "")
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 	return m
 }

--- a/route/consistent_hashing.go
+++ b/route/consistent_hashing.go
@@ -18,8 +18,8 @@ type ConsistentHashing struct {
 	Mutator *RoutingMutator
 }
 
-func NewConsistentHashing(key, prefix, sub, regex string, destinations []*dest.Destination, routingMutator *RoutingMutator, metricSuffix string) (*ConsistentHashing, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewConsistentHashing(key, prefix, sub, regex, notRegex string, destinations []*dest.Destination, routingMutator *RoutingMutator, metricSuffix string) (*ConsistentHashing, error) {
+	m, err := matcher.New(prefix, sub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/route/consistent_hashing_test.go
+++ b/route/consistent_hashing_test.go
@@ -28,7 +28,7 @@ func testBaseCHRoute(nodeNum int) *ConsistentHashing {
 		destMap[addr] = &destination.Destination{Key: addr}
 	}
 	rm, _ := NewRoutingMutator(nil, 0)
-	r := &ConsistentHashing{*newBaseRoute("test_route", "ConsistentHashing"), hashring.New(nodes), rm}
+	r := &ConsistentHashing{*newBaseRoute("test_route", "ConsistentHashing", ""), hashring.New(nodes), rm}
 	r.baseRoute.destMap = destMap
 	return r
 }

--- a/route/kafka.go
+++ b/route/kafka.go
@@ -18,7 +18,7 @@ type Kafka struct {
 	ctx    context.Context
 }
 
-func NewKafkaRoute(key, prefix, sub, regex string, config kafka.WriterConfig, routingMutator *RoutingMutator, metricSuffix string) (*Kafka, error) {
+func NewKafkaRoute(key, prefix, sub, regex, notRegex string, config kafka.WriterConfig, routingMutator *RoutingMutator, metricSuffix string) (*Kafka, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %s", err)
 	}
@@ -35,7 +35,7 @@ func NewKafkaRoute(key, prefix, sub, regex string, config kafka.WriterConfig, ro
 	k.logger = k.logger.With(zap.String("kafka_topic", config.Topic))
 
 	// Don't remember why it's required
-	m, err := matcher.New(prefix, sub, regex)
+	m, err := matcher.New(prefix, sub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/route/kafka.go
+++ b/route/kafka.go
@@ -18,12 +18,12 @@ type Kafka struct {
 	ctx    context.Context
 }
 
-func NewKafkaRoute(key, prefix, sub, regex string, config kafka.WriterConfig, routingMutator *RoutingMutator) (*Kafka, error) {
+func NewKafkaRoute(key, prefix, sub, regex string, config kafka.WriterConfig, routingMutator *RoutingMutator, metricSuffix string) (*Kafka, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %s", err)
 	}
 	k := Kafka{
-		baseRoute: *newBaseRoute(key, "kafka"),
+		baseRoute: *newBaseRoute(key, "kafka", metricSuffix),
 		router:    routingMutator,
 		Writer:    kafka.NewWriter(config),
 		ctx:       context.TODO(),
@@ -51,6 +51,9 @@ func (k *Kafka) Shutdown() error {
 
 func (k *Kafka) Dispatch(dp encoding.Datapoint) {
 	k.rm.InMetrics.Inc()
+	if k.metricSuffix != "" {
+		dp.Name += k.metricSuffix
+	}
 	key := []byte(dp.Name)
 	if newKey, ok := k.router.HandleBuf(key); ok {
 		key = newKey

--- a/route/route.go
+++ b/route/route.go
@@ -96,8 +96,8 @@ type SendFirstMatch struct {
 
 // NewSendAllMatch creates a sendAllMatch route.
 // We will automatically run the route and the given destinations
-func NewSendAllMatch(key, prefix, sub, regex string, destinations []*dest.Destination, metric_suffix string) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewSendAllMatch(key, prefix, sub, regex, notRegex string, destinations []*dest.Destination, metric_suffix string) (Route, error) {
+	m, err := matcher.New(prefix, sub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +109,8 @@ func NewSendAllMatch(key, prefix, sub, regex string, destinations []*dest.Destin
 
 // NewSendFirstMatch creates a sendFirstMatch route.
 // We will automatically run the route and the given destinations
-func NewSendFirstMatch(key, prefix, sub, regex string, destinations []*dest.Destination, metricSuffix string) (Route, error) {
-	m, err := matcher.New(prefix, sub, regex)
+func NewSendFirstMatch(key, prefix, sub, regex, notRegex string, destinations []*dest.Destination, metricSuffix string) (Route, error) {
+	m, err := matcher.New(prefix, sub, regex, notRegex)
 	if err != nil {
 		return nil, err
 	}
@@ -326,6 +326,7 @@ func (route *baseRoute) update(opts map[string]string, extendConfig baseCfgExten
 	prefix := match.Prefix
 	sub := match.Sub
 	regex := match.Regex
+	notRegex := match.NotRegex
 	updateMatcher := false
 
 	for name, val := range opts {
@@ -339,12 +340,15 @@ func (route *baseRoute) update(opts map[string]string, extendConfig baseCfgExten
 		case "regex":
 			regex = val
 			updateMatcher = true
+		case "notRegex":
+			notRegex = val
+			updateMatcher = true
 		default:
 			return fmt.Errorf("no such option '%s'", name)
 		}
 	}
 	if updateMatcher {
-		match, err := matcher.New(prefix, sub, regex)
+		match, err := matcher.New(prefix, sub, regex, notRegex)
 		if err != nil {
 			return err
 		}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -9,7 +9,7 @@ import (
 
 // just sending into route, no matching or sending to dest
 func BenchmarkRouteDispatchMetric(b *testing.B) {
-	route, err := NewSendAllMatch("", "", "", "", make([]*destination.Destination, 0), "")
+	route, err := NewSendAllMatch("", "", "", "", "", make([]*destination.Destination, 0), "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -9,7 +9,7 @@ import (
 
 // just sending into route, no matching or sending to dest
 func BenchmarkRouteDispatchMetric(b *testing.B) {
-	route, err := NewSendAllMatch("", "", "", "", make([]*destination.Destination, 0))
+	route, err := NewSendAllMatch("", "", "", "", make([]*destination.Destination, 0), "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -575,7 +575,6 @@ func (table *Table) InitCmd(config cfg.Config) error {
 			return fmt.Errorf("could not apply init cmd #%d", i+1)
 		}
 	}
-
 	return nil
 }
 
@@ -656,7 +655,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("must get at least 1 destination for route '%s'", routeConfig.Key)
 			}
 
-			route, err := route.NewSendAllMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations)
+			route, err := route.NewSendAllMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations, routeConfig.MetricSuffix)
 			if err != nil {
 				routeConfigLogger.Error("error adding route", zap.Error(err))
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -672,7 +671,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("must get at least 1 destination for route '%s'", routeConfig.Key)
 			}
 
-			route, err := route.NewSendFirstMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations)
+			route, err := route.NewSendFirstMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations, routeConfig.MetricSuffix)
 			if err != nil {
 				routeConfigLogger.Error("error adding route", zap.Error(err))
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -693,7 +692,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("can't create the routing mutator: %s", err)
 			}
 
-			route, err := route.NewConsistentHashing(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations, routingMutator)
+			route, err := route.NewConsistentHashing(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations, routingMutator, routeConfig.MetricSuffix)
 			if err != nil {
 				routeConfigLogger.Error("error adding route", zap.Error(err))
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -750,7 +749,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("can't create the routing mutator: %s", err)
 			}
 
-			route, err := route.NewKafkaRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, writerConfig, routingMutator)
+			route, err := route.NewKafkaRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, writerConfig, routingMutator, routeConfig.MetricSuffix)
 			if err != nil {
 				return fmt.Errorf("Failed to create route: %s", err)
 			}
@@ -835,7 +834,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 			if err != nil {
 				return fmt.Errorf("error adding route '%s': %s", routeConfig.Key, err)
 			}
-			route, err := route.NewBgMetadataRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, bgMetadataCfg.StorageAggregationConfig, bgMetadataCfg.StorageSchemasConfig, bloomFilterConfig, bgMetadataCfg.Storage, additionnalCfg)
+			route, err := route.NewBgMetadataRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, bgMetadataCfg.StorageAggregationConfig, bgMetadataCfg.StorageSchemasConfig, bloomFilterConfig, bgMetadataCfg.Storage, additionnalCfg, routeConfig.MetricSuffix)
 			if err != nil {
 				return fmt.Errorf("error adding route '%s': %s", routeConfig.Key, err)
 			}

--- a/table/table.go
+++ b/table/table.go
@@ -588,6 +588,7 @@ func (table *Table) InitBlacklist(config cfg.Config) error {
 		prefix := ""
 		sub := ""
 		regex := ""
+		notRegex := ""
 
 		switch parts[0] {
 		case "prefix":
@@ -596,11 +597,13 @@ func (table *Table) InitBlacklist(config cfg.Config) error {
 			sub = parts[1]
 		case "regex":
 			regex = parts[1]
+		case "notRegex":
+			notRegex = parts[1]
 		default:
 			return fmt.Errorf("invalid blacklist method for cmd #%d: %s", i+1, parts[1])
 		}
 
-		m, err := matcher.New(prefix, sub, regex)
+		m, err := matcher.New(prefix, sub, regex, notRegex)
 		if err != nil {
 			table.logger.Error("could not apply blacklist cmd", zap.Error(err))
 			return fmt.Errorf("could not apply blacklist cmd #%d", i+1)
@@ -655,7 +658,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("must get at least 1 destination for route '%s'", routeConfig.Key)
 			}
 
-			route, err := route.NewSendAllMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations, routeConfig.MetricSuffix)
+			route, err := route.NewSendAllMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.NotRegex, destinations, routeConfig.MetricSuffix)
 			if err != nil {
 				routeConfigLogger.Error("error adding route", zap.Error(err))
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -671,7 +674,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("must get at least 1 destination for route '%s'", routeConfig.Key)
 			}
 
-			route, err := route.NewSendFirstMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations, routeConfig.MetricSuffix)
+			route, err := route.NewSendFirstMatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.NotRegex, destinations, routeConfig.MetricSuffix)
 			if err != nil {
 				routeConfigLogger.Error("error adding route", zap.Error(err))
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -692,7 +695,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("can't create the routing mutator: %s", err)
 			}
 
-			route, err := route.NewConsistentHashing(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, destinations, routingMutator, routeConfig.MetricSuffix)
+			route, err := route.NewConsistentHashing(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.NotRegex, destinations, routingMutator, routeConfig.MetricSuffix)
 			if err != nil {
 				routeConfigLogger.Error("error adding route", zap.Error(err))
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -749,7 +752,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 				return fmt.Errorf("can't create the routing mutator: %s", err)
 			}
 
-			route, err := route.NewKafkaRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, writerConfig, routingMutator, routeConfig.MetricSuffix)
+			route, err := route.NewKafkaRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.NotRegex, writerConfig, routingMutator, routeConfig.MetricSuffix)
 			if err != nil {
 				return fmt.Errorf("Failed to create route: %s", err)
 			}
@@ -834,7 +837,7 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 			if err != nil {
 				return fmt.Errorf("error adding route '%s': %s", routeConfig.Key, err)
 			}
-			route, err := route.NewBgMetadataRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, bgMetadataCfg.StorageAggregationConfig, bgMetadataCfg.StorageSchemasConfig, bloomFilterConfig, bgMetadataCfg.Storage, additionnalCfg, routeConfig.MetricSuffix)
+			route, err := route.NewBgMetadataRoute(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.NotRegex, bgMetadataCfg.StorageAggregationConfig, bgMetadataCfg.StorageSchemasConfig, bloomFilterConfig, bgMetadataCfg.Storage, additionnalCfg, routeConfig.MetricSuffix)
 			if err != nil {
 				return fmt.Errorf("error adding route '%s': %s", routeConfig.Key, err)
 			}

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -156,6 +156,7 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 		Prefix               string
 		Substring            string
 		Regex                string
+		NotRegex             string
 		Address              string
 		MetricSuffix         string
 		Spool                bool
@@ -176,6 +177,7 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 	}
 	dest, err := destination.New(
 		req.Key,
+		"",
 		"",
 		"",
 		"",
@@ -202,9 +204,9 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 	var e error
 	switch req.Type {
 	case "sendAllMatch":
-		ro, e = route.NewSendAllMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest}, req.MetricSuffix)
+		ro, e = route.NewSendAllMatch(req.Key, req.Prefix, req.Substring, req.Regex, req.NotRegex, []*destination.Destination{dest}, req.MetricSuffix)
 	case "sendFirstMatch":
-		ro, e = route.NewSendFirstMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest}, req.MetricSuffix)
+		ro, e = route.NewSendFirstMatch(req.Key, req.Prefix, req.Substring, req.Regex, req.NotRegex, []*destination.Destination{dest}, req.MetricSuffix)
 	default:
 		return nil, &handlerError{nil, "unknown route type: " + req.Type, http.StatusBadRequest}
 	}

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -157,6 +157,7 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 		Substring            string
 		Regex                string
 		Address              string
+		MetricSuffix         string
 		Spool                bool
 		Pickle               bool
 		periodFlush          int
@@ -201,9 +202,9 @@ func parseRouteRequest(r *http.Request) (route.Route, *handlerError) {
 	var e error
 	switch req.Type {
 	case "sendAllMatch":
-		ro, e = route.NewSendAllMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest})
+		ro, e = route.NewSendAllMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest}, req.MetricSuffix)
 	case "sendFirstMatch":
-		ro, e = route.NewSendFirstMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest})
+		ro, e = route.NewSendFirstMatch(req.Key, req.Prefix, req.Substring, req.Regex, []*destination.Destination{dest}, req.MetricSuffix)
 	default:
 		return nil, &handlerError{nil, "unknown route type: " + req.Type, http.StatusBadRequest}
 	}


### PR DESCRIPTION
Supporting `metric_suffix` and `notRegex` flags for `[[route]]` 
```toml
metric_suffix = ";vm_account_id=0;vm_project_id=666;__retention=medium" # concatenate to every datapoints 
notRegex = ".*counter.sum*" # dropping datapoints having counter.sum in the name 
```
