### PR TITLE
Adding aggregator matched metrics

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -15,32 +15,37 @@ import (
 )
 
 type Aggregator struct {
-	Fun          string `json:"fun"`
-	procConstr   func(val float64, ts uint32) Processor
-	in           chan encoding.Datapoint `json:"-"` // incoming metrics, already split in 3 fields
-	out          chan encoding.Datapoint // outgoing metrics
-	Regex        string                  `json:"regex,omitempty"`
-	Prefix       string                  `json:"prefix,omitempty"`
-	Sub          string                  `json:"substring,omitempty"`
-	regex        *regexp.Regexp          // compiled version of Regex
-	prefix       []byte                  // automatically generated based on Prefix or regex, for fast preMatch
-	substring    []byte                  // based on Sub, for fast preMatch
-	OutFmt       string
-	outFmt       []byte
-	Cache        bool
-	reCache      map[string]CacheEntry
-	reCacheMutex sync.Mutex
-	Interval     uint                 // expected interval between values in seconds, we will quantize to make sure alginment to interval-spaced timestamps
-	Wait         uint                 // seconds to wait after quantized time value before flushing final outcome and ignoring future values that are sent too late.
-	DropRaw      bool                 // drop raw values "consumed" by this aggregator
-	aggregations map[aggkey]Processor // aggregations in process: one for each quantized timestamp and output key, i.e. for each output metric.
-	snapReq      chan bool            // chan to issue snapshot requests on
-	snapResp     chan *Aggregator     // chan on which snapshot response gets sent
-	shutdown     chan struct{}        // chan used internally to shut down
-	wg           sync.WaitGroup       // tracks worker running state
-	now          func() time.Time     // returns current time. wraps time.Now except in some unit tests
-	tick         <-chan time.Time     // controls when to flush
-	am           *metrics.AggregatorMetrics
+	Fun                    string `json:"fun"`
+	procConstr             func(val float64, ts uint32) Processor
+	in                     chan encoding.Datapoint `json:"-"` // incoming metrics, already split in 3 fields
+	out                    chan encoding.Datapoint // outgoing metrics
+	Regex                  string                  `json:"regex,omitempty"`
+	Prefix                 string                  `json:"prefix,omitempty"`
+	Sub                    string                  `json:"substring,omitempty"`
+	regex                  *regexp.Regexp          // compiled version of Regex
+	prefix                 []byte                  // automatically generated based on Prefix or regex, for fast preMatch
+	substring              []byte                  // based on Sub, for fast preMatch
+	OutFmt                 string
+	outFmt                 []byte
+	Cache                  bool
+	reCache                map[string]CacheEntry
+	reCacheMutex           sync.Mutex
+	Interval               uint                 // expected interval between values in seconds, we will quantize to make sure alginment to interval-spaced timestamps
+	Wait                   uint                 // seconds to wait after quantized time value before flushing final outcome and ignoring future values that are sent too late.
+	DropRaw                bool                 // drop raw values "consumed" by this aggregator
+	aggregations           map[aggkey]Processor // aggregations in process: one for each quantized timestamp and output key, i.e. for each output metric.
+	snapReq                chan bool            // chan to issue snapshot requests on
+	snapResp               chan *Aggregator     // chan on which snapshot response gets sent
+	shutdown               chan struct{}        // chan used internally to shut down
+	wg                     sync.WaitGroup       // tracks worker running state
+	now                    func() time.Time     // returns current time. wraps time.Now except in some unit tests
+	tick                   <-chan time.Time     // controls when to flush
+	am                     *metrics.AggregatorMetrics
+	exposeMatchedMetrics   bool `json:"expose_matched_metrics"`    // if a metric should expose the number of input is matched
+	matchedMetricPathIndex uint `json:"matched_metric_path_index"` // this flag controls what is part of the path is exposed
+	// in the metric:
+	// for instance if set to 2
+	// my.metric.path.key.value will expose "path"
 }
 
 // regexToPrefix inspects the regex and returns the longest static prefix part of the regex
@@ -72,11 +77,11 @@ func regexToPrefix(regex string) []byte {
 }
 
 // New creates an aggregator
-func New(fun, regex, prefix, sub, outFmt string, cache bool, interval, wait uint, dropRaw bool, out chan encoding.Datapoint) (*Aggregator, error) {
-	return NewMocked(fun, regex, prefix, sub, outFmt, cache, interval, wait, dropRaw, out, 2000, time.Now, clock.AlignedTick(time.Duration(interval)*time.Second))
+func New(fun, regex, prefix, sub, outFmt string, cache bool, interval, wait uint, dropRaw bool, out chan encoding.Datapoint, exposeMetrics bool, exposeMetricIndex uint) (*Aggregator, error) {
+	return NewMocked(fun, regex, prefix, sub, outFmt, cache, interval, wait, dropRaw, out, 2000, time.Now, clock.AlignedTick(time.Duration(interval)*time.Second), exposeMetrics, exposeMetricIndex)
 }
 
-func NewMocked(fun, regex, prefix, sub, outFmt string, cache bool, interval, wait uint, dropRaw bool, out chan encoding.Datapoint, inBuf int, now func() time.Time, tick <-chan time.Time) (*Aggregator, error) {
+func NewMocked(fun, regex, prefix, sub, outFmt string, cache bool, interval, wait uint, dropRaw bool, out chan encoding.Datapoint, inBuf int, now func() time.Time, tick <-chan time.Time, exposeMetrics bool, exposeMetricIndex uint) (*Aggregator, error) {
 	regexObj, err := regexp.Compile(regex)
 	if err != nil {
 		return nil, err
@@ -87,27 +92,29 @@ func NewMocked(fun, regex, prefix, sub, outFmt string, cache bool, interval, wai
 	}
 
 	a := &Aggregator{
-		Fun:          fun,
-		procConstr:   procConstr,
-		in:           make(chan encoding.Datapoint, inBuf),
-		out:          out,
-		Regex:        regex,
-		Sub:          sub,
-		regex:        regexObj,
-		substring:    []byte(sub),
-		OutFmt:       outFmt,
-		outFmt:       []byte(outFmt),
-		Cache:        cache,
-		Interval:     interval,
-		Wait:         wait,
-		DropRaw:      dropRaw,
-		aggregations: make(map[aggkey]Processor),
-		snapReq:      make(chan bool),
-		snapResp:     make(chan *Aggregator),
-		shutdown:     make(chan struct{}),
-		now:          now,
-		tick:         tick,
-		am:           metrics.NewAggregatorMetrics(prefix, nil),
+		Fun:                    fun,
+		procConstr:             procConstr,
+		in:                     make(chan encoding.Datapoint, inBuf),
+		out:                    out,
+		Regex:                  regex,
+		Sub:                    sub,
+		regex:                  regexObj,
+		substring:              []byte(sub),
+		OutFmt:                 outFmt,
+		outFmt:                 []byte(outFmt),
+		Cache:                  cache,
+		Interval:               interval,
+		Wait:                   wait,
+		DropRaw:                dropRaw,
+		aggregations:           make(map[aggkey]Processor),
+		snapReq:                make(chan bool),
+		snapResp:               make(chan *Aggregator),
+		shutdown:               make(chan struct{}),
+		now:                    now,
+		tick:                   tick,
+		am:                     metrics.NewAggregatorMetrics(prefix, nil),
+		exposeMatchedMetrics:   exposeMetrics,
+		matchedMetricPathIndex: exposeMetricIndex,
 	}
 	if prefix != "" {
 		a.prefix = []byte(prefix)
@@ -177,6 +184,13 @@ func (a *Aggregator) Flush(ts uint) {
 func (a *Aggregator) Shutdown() {
 	close(a.shutdown)
 	a.wg.Wait()
+}
+
+func (a *Aggregator) IncrementMetric(key string) {
+	path := strings.Split(key, ".")
+	if uint(len(path)) > a.matchedMetricPathIndex {
+		a.am.Matched.WithLabelValues(path[a.matchedMetricPathIndex]).Inc()
+	}
 }
 
 func (a *Aggregator) AddMaybe(dp encoding.Datapoint) bool {
@@ -276,6 +290,9 @@ func (a *Aggregator) run() {
 			outKey, ok := a.matchWithCacheString(msg.Name)
 			if !ok {
 				continue
+			}
+			if a.exposeMatchedMetrics {
+				a.IncrementMetric(outKey)
 			}
 			//TODO: m.conraux Remove int casting logic
 			ts := uint(msg.Timestamp)

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -186,11 +186,25 @@ func (a *Aggregator) Shutdown() {
 	a.wg.Wait()
 }
 
-func (a *Aggregator) IncrementMetric(key string) {
-	path := strings.Split(key, ".")
-	if uint(len(path)) > a.matchedMetricPathIndex {
-		a.am.Matched.WithLabelValues(path[a.matchedMetricPathIndex]).Inc()
+func getStringIndex(key string, index uint) string {
+	start := 0
+	for i := uint(0); i < index; i++ {
+		pos := strings.IndexByte(key[start:], '.')
+		if pos == -1 {
+			return ""
+		}
+		start += pos + 1
 	}
+
+	end := strings.IndexByte(key[start:], '.')
+	if end == -1 {
+		return key[start:]
+	}
+	return key[start : start+end]
+}
+
+func (a *Aggregator) IncrementMetric(key string) {
+	a.am.Matched.WithLabelValues(getStringIndex(key, a.matchedMetricPathIndex)).Inc()
 }
 
 func (a *Aggregator) AddMaybe(dp encoding.Datapoint) bool {

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -1,6 +1,7 @@
 package aggregator
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -291,7 +292,7 @@ func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, cache
 	clock.AddTick(tick)
 	bufSize := 2 * aggregates * pointsPerAggregate
 
-	agg, err := NewMocked("sum", regex, "", "", outFmt, cache, 10, 30, false, out, bufSize, clock.Now, tick.C)
+	agg, err := NewMocked("sum", regex, "", "", outFmt, cache, 10, 30, false, out, bufSize, clock.Now, tick.C, true, 0)
 	if err != nil {
 		b.Fatalf("couldn't create aggregation: %q", err)
 	}
@@ -337,5 +338,37 @@ func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, cache
 			lastFlushTs += 10
 			time.Sleep(10 * time.Microsecond)
 		}
+	}
+}
+
+func TestGetStringIndex(t *testing.T) {
+	tests := []struct {
+		key      string
+		index    uint
+		expected string
+	}{
+		{"foo.bar.baz", 0, "foo"},
+		{"foo.bar.baz", 1, "bar"},
+		{"foo.bar.baz", 2, "baz"},
+		{"foo.bar.baz", 3, ""},
+		{"one.two.three.four", 2, "three"},
+		{"justone", 0, "justone"},
+		{"justone", 1, ""},
+		{"", 0, ""},
+		{".starting.dot", 0, ""},
+		{".starting.dot", 1, "starting"},
+		{"ending.dot.", 2, ""},
+		{"double..dot", 1, ""},
+		{"multiple.dots.in.a.row", 4, "row"},
+		{"multiple.dots.in.a.row", 5, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q[%d]", tt.key, tt.index), func(t *testing.T) {
+			result := getStringIndex(tt.key, tt.index)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
 	}
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -56,8 +56,8 @@ type Aggregation struct {
 	Interval             int
 	Wait                 int
 	DropRaw              bool
-	ExposeMatchedMetrics bool `toml:"exposed_matched_metrics,omitempty"`
-	MatchedMetricPath    uint `toml:"matched_metric_path,omitempty"`
+	ExposeMatchedMetrics bool
+	MatchedMetricPath    uint
 }
 
 type Route struct {

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -47,15 +47,17 @@ func (d *Duration) UnmarshalText(text []byte) error {
 }
 
 type Aggregation struct {
-	Function string
-	Regex    string
-	Prefix   string
-	Substr   string
-	Format   string
-	Cache    bool
-	Interval int
-	Wait     int
-	DropRaw  bool
+	Function             string
+	Regex                string
+	Prefix               string
+	Substr               string
+	Format               string
+	Cache                bool
+	Interval             int
+	Wait                 int
+	DropRaw              bool
+	ExposeMatchedMetrics bool `toml:"exposed_matched_metrics,omitempty"`
+	MatchedMetricPath    uint `toml:"matched_metric_path,omitempty"`
 }
 
 type Route struct {

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -297,7 +297,7 @@ func readAddAgg(s *toki.Scanner, table Table) error {
 		}
 	}
 
-	agg, err := aggregator.New(fun, regex, prefix, sub, outFmt, cache, uint(interval), uint(wait), dropRaw, table.GetIn())
+	agg, err := aggregator.New(fun, regex, prefix, sub, outFmt, cache, uint(interval), uint(wait), dropRaw, table.GetIn(), false, 0)
 	if err != nil {
 		return err
 	}

--- a/metrics/aggregator_metrics.go
+++ b/metrics/aggregator_metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"strconv"
 )
 
 const aggregatorNamespace = "aggregator"
@@ -13,6 +14,8 @@ type CacheMetrics struct {
 	Hits   prometheus.Counter
 	Misses prometheus.Counter
 }
+
+var aggregatorIdCount = 0
 
 func NewCacheMetrics(namespace string, labels prometheus.Labels) *CacheMetrics {
 	cm := CacheMetrics{}
@@ -31,9 +34,10 @@ func NewCacheMetrics(namespace string, labels prometheus.Labels) *CacheMetrics {
 }
 
 type AggregatorMetrics struct {
-	Cache                   *CacheMetrics
-	Dropped                 prometheus.Counter
-	Matched                 *prometheus.CounterVec
+	Cache   *CacheMetrics
+	Dropped prometheus.Counter
+	Matched *prometheus.CounterVec
+	prometheus.Gauge
 	lowestTimestampCounter  prometheus.Gauge
 	highestTimestampCounter prometheus.Gauge
 	highTs                  uint32
@@ -48,7 +52,12 @@ func NewAggregatorMetrics(id string, labels prometheus.Labels) *AggregatorMetric
 	if labels == nil {
 		labels = prometheus.Labels{}
 	}
-	labels["id"] = id
+	if id == "" {
+		labels["id"] = strconv.Itoa(aggregatorIdCount)
+		aggregatorIdCount++
+	} else {
+		labels["id"] = id
+	}
 
 	am.Cache = NewCacheMetrics(namespace, labels)
 	am.Dropped = promauto.NewCounter(prometheus.CounterOpts{

--- a/metrics/aggregator_metrics.go
+++ b/metrics/aggregator_metrics.go
@@ -33,6 +33,7 @@ func NewCacheMetrics(namespace string, labels prometheus.Labels) *CacheMetrics {
 type AggregatorMetrics struct {
 	Cache                   *CacheMetrics
 	Dropped                 prometheus.Counter
+	Matched                 *prometheus.CounterVec
 	lowestTimestampCounter  prometheus.Gauge
 	highestTimestampCounter prometheus.Gauge
 	highTs                  uint32
@@ -56,6 +57,14 @@ func NewAggregatorMetrics(id string, labels prometheus.Labels) *AggregatorMetric
 		Help:        "Total number of metrics dropped because of their age",
 		ConstLabels: labels,
 	})
+
+	am.Matched = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   namespace,
+		Name:        "matched_metrics_total",
+		Help:        "Total number of metrics matched by the aggregator, grouped by an index in the path",
+		ConstLabels: labels,
+	}, []string{"matched_path"})
+
 	tsVec := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   namespace,
 		Name:        "timestamp_value",

--- a/table/table.go
+++ b/table/table.go
@@ -617,7 +617,7 @@ func (table *Table) InitBlacklist(config cfg.Config) error {
 
 func (table *Table) InitAggregation(config cfg.Config) error {
 	for i, aggConfig := range config.Aggregation {
-		agg, err := aggregator.New(aggConfig.Function, aggConfig.Regex, aggConfig.Prefix, aggConfig.Substr, aggConfig.Format, aggConfig.Cache, uint(aggConfig.Interval), uint(aggConfig.Wait), aggConfig.DropRaw, table.In)
+		agg, err := aggregator.New(aggConfig.Function, aggConfig.Regex, aggConfig.Prefix, aggConfig.Substr, aggConfig.Format, aggConfig.Cache, uint(aggConfig.Interval), uint(aggConfig.Wait), aggConfig.DropRaw, table.In, aggConfig.ExposeMatchedMetrics, aggConfig.MatchedMetricPath)
 		if err != nil {
 			table.logger.Error("could not add aggregation", zap.Error(err))
 			return fmt.Errorf("could not add aggregation #%d", i+1)

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -231,7 +231,7 @@ func parseAggregateRequest(r *http.Request) (*aggregator.Aggregator, *handlerErr
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, &handlerError{err, "Couldn't parse json", http.StatusBadRequest}
 	}
-	aggregate, err := aggregator.New(request.Fun, request.Regex, request.Prefix, request.Substring, request.OutFmt, request.Cache, request.Interval, request.Wait, request.DropRaw, table.In)
+	aggregate, err := aggregator.New(request.Fun, request.Regex, request.Prefix, request.Substring, request.OutFmt, request.Cache, request.Interval, request.Wait, request.DropRaw, table.In, false, 0)
 	if err != nil {
 		return nil, &handlerError{err, "Couldn't create aggregator", http.StatusBadRequest}
 	}


### PR DESCRIPTION
This is to add a counter to store the matched metrics, to not explose cardinality, its only storing 1 field of the metric for instance:

metric.agglo.my_app.my.metric
with index 2 will store my_app